### PR TITLE
Support simple "feature selection" in CoorAscent:

### DIFF
--- a/src/main/java/ciir/umass/edu/learning/CoorAscent.java
+++ b/src/main/java/ciir/umass/edu/learning/CoorAscent.java
@@ -72,7 +72,7 @@ public class CoorAscent extends Ranker {
         double[] bestModel = null;
         double bestModelScore = 0.0;
 
-        int[] sign = new int[]{1, -1};
+        int[] sign = new int[]{1, -1, 0};
 
         PRINTLN("---------------------------");
         PRINTLN("Training starts...");
@@ -113,11 +113,17 @@ public class CoorAscent extends Ranker {
                     boolean succeeds = false;//whether or not we succeed in finding a better weight value for the current feature
                     for (int s = 0; s < sign.length; s++)//search by both increasing and decreasing
                     {
-                        double step = 0.001 * sign[s];
+                        int dir = sign[s];
+                        double step = 0.001 * dir;
                         if (origWeight != 0.0 && Math.abs(step) > 0.5 * Math.abs(origWeight))
                             step = stepBase * Math.abs(origWeight);
                         totalStep = step;
-                        for (int j = 0; j < nMaxIteration; j++) {
+                        int numIter = nMaxIteration;
+                        if(dir == 0) {
+                            numIter = 1;
+                            totalStep = -origWeight;
+                        }
+                        for (int j = 0; j < numIter; j++) {
                             double w = origWeight + totalStep;
                             weight_change = step;//weight_change is used in the "else" branch in the procedure rank()
                             weight[fids[i]] = w;


### PR DESCRIPTION
Every time we try to optimize for a single feature, consider giving it a weight of zero, no matter where the search took us before. Gives us a chance to lose features that only hurt while optimizing.

We do this by adding a "0" direction, and then for efficiency only take 1 "iteration" in that direction. Since RankLib has the `currentWeight` as always calculated from `origWeight + totalStep`, we set `totalStep=-origWeight` in order to reach zero.
